### PR TITLE
Add initial issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,7 +29,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Meadow (please complete the following information as best as you can):**
 Most of these vaues can be found by running `meadow device info` using the [Meadow CLI](http://developer.wildernesslabs.co/Meadow/Meadow_Basics/Meadow_CLI/).
- - Meadow hardware: [e.g. F7Micro F7v2, Core-Compute Module]
+ - Meadow hardware version: [e.g. F7v2, CCMv2]
  - Meadow OS version: [e.g., v0.6.7.19]
  - If they are different, please provide these versions as well.
    - Meadow Mono version: [e.g., v0.6.7.19]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Developer tools (please complete the following information as best as you can):**
+ - OS and version: [e.g., Windows 10 v22H2, macOS Monterey v12.6]
+ - IDE and version: [e.g., Visual Studio Professional 2022 v17.3.5, Visual Studio 2022 for Mac v17.3.5]
+ - Meadow extension for IDE version: [e.g., VS 2022 Tools for Meadow v0.19.9]
+
+**Meadow (please complete the following information as best as you can):**
+Most of these vaues can be found by running `meadow device info` using the [Meadow CLI](http://developer.wildernesslabs.co/Meadow/Meadow_Basics/Meadow_CLI/).
+ - Meadow hardware: [e.g. F7Micro F7v2, Core-Compute Module]
+ - Meadow OS version: [e.g., v0.6.7.19]
+ - If they are different, please provide these versions as well.
+   - Meadow Mono version: [e.g., v0.6.7.19]
+   - Meadow coprocessor version: [e.g., v0.6.7.19]
+
+**Additional context**
+Add any other context about the problem here. If you are working with additional external hardware/sensors, please list them here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for Meadow
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Initial bug report and feature request templates to make sure we are getting as much useful information as we can. I customized the samples as best as I could for Meadow to help track down version or hardware-specific issues.

Potential additional considerations:

- [ ] Do we want any other additional user environment details?
- [ ] Any extra considerations for feature requests?
- [x] What does `meadow device info` output for Core-Compute Module for use in example Meadow hardware details?